### PR TITLE
feat!(cookie): Remove hide skull prefs

### DIFF
--- a/addons/sourcemod/scripting/include/TopInfectors.inc
+++ b/addons/sourcemod/scripting/include/TopInfectors.inc
@@ -10,7 +10,7 @@
 
 #define TopInfectors_V_MAJOR   "1"
 #define TopInfectors_V_MINOR   "5"
-#define TopInfectors_V_PATCH   "4"
+#define TopInfectors_V_PATCH   "5"
 
 #define TopInfectors_VERSION   TopInfectors_V_MAJOR..."."...TopInfectors_V_MINOR..."."...TopInfectors_V_PATCH
 


### PR DESCRIPTION
On 25 662 cookies stored only 45 has the skull disabled, that's 0.175% of players.
I doesn't make sense to keep it, the command still present for players who want to hide skull.